### PR TITLE
A Couple of macOS VST build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+BUILT_VST/
+xcode-output/
+

--- a/scripts/build-all-vst.pl
+++ b/scripts/build-all-vst.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/perl
+
+use File::Find;
+    
+# Traverse desired filesystems
+sub wanted {
+    my $file = $_;
+    my $dir = $File::Find::dir;
+    if( $file =~ /.xcodeproj$/ )
+    {
+        $cmd = "../../../scripts/upgrade-xcode-vst.sh $file; cd ../../..; mv xcode-output/$file/build/Release/*vst BUILT_VST";
+        print $cmd . "\n";
+        system( $cmd );
+    }
+
+}
+
+system( "mkdir -p BUILT_VST" );
+find(\&wanted, "plugins/MacVST");
+

--- a/scripts/upgrade-xcode-vst.sh
+++ b/scripts/upgrade-xcode-vst.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+if [[ -z $VST2SDK_DIR ]]; then
+    echo "VST2SDK_DIR must be set to a valid VST location"
+    exit 1
+fi
+
+if [[ ! -d $1 ]]; then
+    echo "USAGE: upgrade-xcode.sh foo.xcodeproj"
+    exit 2
+fi
+
+if [[ ! -f $1/project.pbxproj ]]; then
+    echo "$1 is not an xcode project. project.pbxproj does not exist"
+    exit 3
+fi
+
+
+perl -i -p -e "s:([\"\s])/vstsdk2.4:\1$VST2SDK_DIR:" $1/project.pbxproj
+perl -i -p -e 's/= 10\.4/= 10.11/' $1/project.pbxproj
+perl -i -p -e 's:SDKROOT\s*=.*;:SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk;:' $1/project.pbxproj
+perl -i -p -e 's/i386/x86_64/' $1/project.pbxproj
+
+xcodebuild build -configuration Release -project $1 SYMROOT=../../../xcode-output/$1/build
+
+echo "Restoring xcode project to prior state"
+git checkout master $1


### PR DESCRIPTION
Hey, cool plugins. One of the members of the surge-synth-team recently upgraded to Catalina and used your plugs and wondered how to get a 64 bit version. I understand you are taking an approach of extreme backwards compatibility (your Xcode projects are for x86 and sdk 10.5) which is cool, but I banged together some scripts which modify the Xcode projects in place to upgrade the SDK, change to 64 bit, and, most importantly, point to your local copy of the VST2SDK if you have one.

Don't know if you are interested in these, but I figured I would send them over. I was able to build al the VSTs and load a few of them I hand checked in 64 bit Reaper on Catalina using the prescription below. Yours if you want them, and no offense if you don't or if you want to restructure them or even if you just think this is a bad idea or whatever!

I'm going to take a shot at a parallel version for the AUs also but the SDK reference is not quite as easy there. Will send a separate PR if I do that.

And thanks again for maintaining cool open source audio software.


------------

These scripts allow you to build on macOS catalina and generate
a set of 64 bit VST2 plugins if you have your own copy of the VST2SDK
to hand. To use them

export VST2SDK_DIR=/Full/Path/To/vstsdk2.4
cd airwindows
perl ./scripts/build-all-vstpl
(wait 10-15 minutes)
look in BUILT_VST and you will see your plugins