### PR TITLE
Fix unitialized variables

### DIFF
--- a/plugins/LinuxVST/src/BuildATPDF/BuildATPDF.cpp
+++ b/plugins/LinuxVST/src/BuildATPDF/BuildATPDF.cpp
@@ -22,6 +22,8 @@ BuildATPDF::BuildATPDF(audioMasterCallback audioMaster) :
 	H = 0.5;
 	I = 0.5;
 	J = 0.5;
+	memset(bL, 0, sizeof(bL));
+	memset(bR, 0, sizeof(bR));
 	//this is reset: values being initialized only once. Startup values, whatever they are.
 	
     _canDo.insert("plugAsChannelInsert"); // plug-in can be used as a channel insert effect.

--- a/plugins/LinuxVST/src/IronOxideClassic2/IronOxideClassic2.cpp
+++ b/plugins/LinuxVST/src/IronOxideClassic2/IronOxideClassic2.cpp
@@ -26,6 +26,8 @@ IronOxideClassic2::IronOxideClassic2(audioMasterCallback audioMaster) :
 	flip = true;
 	fpdL = 1.0; while (fpdL < 16386) fpdL = rand()*UINT32_MAX;
 	fpdR = 1.0; while (fpdR < 16386) fpdR = rand()*UINT32_MAX;
+	cycle = 0;
+	memset(lastRefL, 0, sizeof(lastRefL));
 	//this is reset: values being initialized only once. Startup values, whatever they are.
 	
     _canDo.insert("plugAsChannelInsert"); // plug-in can be used as a channel insert effect.

--- a/plugins/LinuxVST/src/PodcastDeluxe/PodcastDeluxe.cpp
+++ b/plugins/LinuxVST/src/PodcastDeluxe/PodcastDeluxe.cpp
@@ -33,6 +33,7 @@ PodcastDeluxe::PodcastDeluxe(audioMasterCallback audioMaster) :
 	c1R = 2.0; c2R = 2.0; c3R = 2.0; c4R = 2.0; c5R = 2.0; //startup comp gains	
 	
 	fpd = 17;
+	lastSampleL = lastOutSampleL = lastSampleR = lastOutSampleR = 0.0;
 	//this is reset: values being initialized only once. Startup values, whatever they are.
 	
     _canDo.insert("plugAsChannelInsert"); // plug-in can be used as a channel insert effect.

--- a/plugins/LinuxVST/src/ResEQ/ResEQ.cpp
+++ b/plugins/LinuxVST/src/ResEQ/ResEQ.cpp
@@ -22,6 +22,11 @@ ResEQ::ResEQ(audioMasterCallback audioMaster) :
 	H = 0.0;
 	I = 0.0;
 	fpd = 17;
+	framenumber = 0;
+	memset(bL, 0, sizeof(bL));
+	memset(fL, 0, sizeof(fL));
+	memset(bR, 0, sizeof(bR));
+	memset(fR, 0, sizeof(fR));
 	//this is reset: values being initialized only once. Startup values, whatever they are.
 	
     _canDo.insert("plugAsChannelInsert"); // plug-in can be used as a channel insert effect.

--- a/plugins/LinuxVST/src/Slew/Slew.cpp
+++ b/plugins/LinuxVST/src/Slew/Slew.cpp
@@ -18,6 +18,7 @@ Slew::Slew(audioMasterCallback audioMaster) :
 {
 	lastSampleL = 0.0;
 	lastSampleR = 0.0;
+	gain = 0.0;
 
 // TODO: uncomment canDo entries according to your plugin's capabilities
 //    _canDo.insert("sendVstEvents"); // plug-in will send Vst events to Host.

--- a/plugins/LinuxVST/src/StarChild/StarChild.cpp
+++ b/plugins/LinuxVST/src/StarChild/StarChild.cpp
@@ -24,6 +24,7 @@ StarChild::StarChild(audioMasterCallback audioMaster) :
 	
 	wearLPrev = 0.0; wearRPrev = 0.0;
 	
+	p[0] = 0;
 	p[1] = 11; p[2] = 13; p[3] = 17; p[4] = 19; p[5] = 23; p[6] = 29; p[7] = 31; p[8] = 37; p[9] = 41;
 	p[10] = 43; p[11] = 47; p[12] = 53; p[13] = 59; p[14] = 61; p[15] = 67; p[16] = 71; p[17] = 73; p[18] = 79; p[19] = 83; p[20] = 89;
 	p[21] = 97; p[22] = 101; p[23] = 103; p[24] = 107; p[25] = 109; p[26] = 113; p[27] = 127; p[28] = 131; p[29] = 137; p[30] = 139;
@@ -67,6 +68,7 @@ StarChild::StarChild(audioMasterCallback audioMaster) :
 	
 	fpNShapeL = 0.0;
 	fpNShapeR = 0.0;
+	dCount = 0;
 	//this is reset: values being initialized only once. Startup values, whatever they are.
 	
     _canDo.insert("plugAsChannelInsert"); // plug-in can be used as a channel insert effect.


### PR DESCRIPTION
When trying a few plugins, I noticed ResEQ produced a very loud noise when loaded.
Doing some debugging could be seen some variables were not initialized.
I ran through the entire plugin collection through valgrind (in Linux) and fixed up things to the best of my knowledge.
