### PR TITLE
Replace rand() with realtime-safe pcg-rand #28

### DIFF
--- a/plugins/LinuxVST/src/Deckwrecka/DeckwreckaProc.cpp
+++ b/plugins/LinuxVST/src/Deckwrecka/DeckwreckaProc.cpp
@@ -41,22 +41,23 @@ void Deckwrecka::processReplacing(float **inputs, float **outputs, VstInt32 samp
 		bflip++;
 		if (bflip < 1 || bflip > 3) bflip = 1;
 
-		randyL = (rand()/(double)RAND_MAX);
-		randyL += (rand()/(double)RAND_MAX);
-		randyL += (rand()/(double)RAND_MAX);
-		randyL += (rand()/(double)RAND_MAX);
-		randyL += (rand()/(double)RAND_MAX);
-		randyL += (rand()/(double)RAND_MAX);
+		/* Are 6 random calls really needed? */
+		randyL =  _pcg.rand_uf ();
+		randyL += _pcg.rand_uf ();
+		randyL += _pcg.rand_uf ();
+		randyL += _pcg.rand_uf ();
+		randyL += _pcg.rand_uf ();
+		randyL += _pcg.rand_uf ();
 		randyL /= 6.0;
 		randyL *= wreck; //0 to 1 the noise, may not be needed
 		//set up the noise
 
-		randyR = (rand()/(double)RAND_MAX);
-		randyR += (rand()/(double)RAND_MAX);
-		randyR += (rand()/(double)RAND_MAX);
-		randyR += (rand()/(double)RAND_MAX);
-		randyR += (rand()/(double)RAND_MAX);
-		randyR += (rand()/(double)RAND_MAX);
+		randyR =  _pcg.rand_uf ();
+		randyR += _pcg.rand_uf ();
+		randyR += _pcg.rand_uf ();
+		randyR += _pcg.rand_uf ();
+		randyR += _pcg.rand_uf ();
+		randyR += _pcg.rand_uf ();
 		randyR /= 6.0;
 		randyR *= wreck; //0 to 1 the noise, may not be needed
 		//set up the noise
@@ -226,22 +227,22 @@ void Deckwrecka::processDoubleReplacing(double **inputs, double **outputs, VstIn
 		bflip++;
 		if (bflip < 1 || bflip > 3) bflip = 1;
 		
-		randyL = (rand()/(double)RAND_MAX);
-		randyL += (rand()/(double)RAND_MAX);
-		randyL += (rand()/(double)RAND_MAX);
-		randyL += (rand()/(double)RAND_MAX);
-		randyL += (rand()/(double)RAND_MAX);
-		randyL += (rand()/(double)RAND_MAX);
+		randyL =  _pcg.rand_uf ();
+		randyL += _pcg.rand_uf ();
+		randyL += _pcg.rand_uf ();
+		randyL += _pcg.rand_uf ();
+		randyL += _pcg.rand_uf ();
+		randyL += _pcg.rand_uf ();
 		randyL /= 6.0;
 		randyL *= wreck; //0 to 1 the noise, may not be needed
 		//set up the noise
 		
-		randyR = (rand()/(double)RAND_MAX);
-		randyR += (rand()/(double)RAND_MAX);
-		randyR += (rand()/(double)RAND_MAX);
-		randyR += (rand()/(double)RAND_MAX);
-		randyR += (rand()/(double)RAND_MAX);
-		randyR += (rand()/(double)RAND_MAX);
+		randyR =  _pcg.rand_uf ();
+		randyR += _pcg.rand_uf ();
+		randyR += _pcg.rand_uf ();
+		randyR += _pcg.rand_uf ();
+		randyR += _pcg.rand_uf ();
+		randyR += _pcg.rand_uf ();
 		randyR /= 6.0;
 		randyR *= wreck; //0 to 1 the noise, may not be needed
 		//set up the noise


### PR DESCRIPTION
On unices (Linux and macOS) the call to rand() takes a
lock (preserve global random seed) and is hence not realtime-safe.

On Windows this is less of an issue since rand() uses a thread-local
variable by default. However PCG-rand is still a preferable alternative.

--
NOTE: THIS CODE IS UNTESTED!
Other plugins using rand() should be updated likewise.