### PR TITLE
SubsOnly: fix initialization of fpdL/fpdR

### DIFF
--- a/plugins/LinuxVST/src/SubsOnly/SubsOnly.cpp
+++ b/plugins/LinuxVST/src/SubsOnly/SubsOnly.cpp
@@ -65,6 +65,9 @@ SubsOnly::SubsOnly(audioMasterCallback audioMaster) :
 	iirSampleXR = 0.0;
 	iirSampleYR = 0.0;
 	iirSampleZR = 0.0;
+
+	fpdL = 1.0; while (fpdL < 16386) fpdL = rand()*UINT32_MAX;
+	fpdR = 1.0; while (fpdR < 16386) fpdR = rand()*UINT32_MAX;
 	
     _canDo.insert("plugAsChannelInsert"); // plug-in can be used as a channel insert effect.
     _canDo.insert("plugAsSend"); // plug-in can be used as a send effect.

--- a/plugins/MacSignedVST/SubsOnly/source/SubsOnly.cpp
+++ b/plugins/MacSignedVST/SubsOnly/source/SubsOnly.cpp
@@ -65,6 +65,9 @@ SubsOnly::SubsOnly(audioMasterCallback audioMaster) :
 	iirSampleXR = 0.0;
 	iirSampleYR = 0.0;
 	iirSampleZR = 0.0;
+
+	fpdL = 1.0; while (fpdL < 16386) fpdL = rand()*UINT32_MAX;
+	fpdR = 1.0; while (fpdR < 16386) fpdR = rand()*UINT32_MAX;
 	
     _canDo.insert("plugAsChannelInsert"); // plug-in can be used as a channel insert effect.
     _canDo.insert("plugAsSend"); // plug-in can be used as a send effect.

--- a/plugins/MacVST/SubsOnly/source/SubsOnly.cpp
+++ b/plugins/MacVST/SubsOnly/source/SubsOnly.cpp
@@ -65,6 +65,9 @@ SubsOnly::SubsOnly(audioMasterCallback audioMaster) :
 	iirSampleXR = 0.0;
 	iirSampleYR = 0.0;
 	iirSampleZR = 0.0;
+
+	fpdL = 1.0; while (fpdL < 16386) fpdL = rand()*UINT32_MAX;
+	fpdR = 1.0; while (fpdR < 16386) fpdR = rand()*UINT32_MAX;
 	
     _canDo.insert("plugAsChannelInsert"); // plug-in can be used as a channel insert effect.
     _canDo.insert("plugAsSend"); // plug-in can be used as a send effect.

--- a/plugins/WinVST/SubsOnly/SubsOnly.cpp
+++ b/plugins/WinVST/SubsOnly/SubsOnly.cpp
@@ -65,6 +65,9 @@ SubsOnly::SubsOnly(audioMasterCallback audioMaster) :
 	iirSampleXR = 0.0;
 	iirSampleYR = 0.0;
 	iirSampleZR = 0.0;
+
+	fpdL = 1.0; while (fpdL < 16386) fpdL = rand()*UINT32_MAX;
+	fpdR = 1.0; while (fpdR < 16386) fpdR = rand()*UINT32_MAX;
 	
     _canDo.insert("plugAsChannelInsert"); // plug-in can be used as a channel insert effect.
     _canDo.insert("plugAsSend"); // plug-in can be used as a send effect.


### PR DESCRIPTION
`fpdL` and `fpdR` are currently not being initialized properly in SubsOnly.